### PR TITLE
Lodash version update because of vulnerability issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/calenicolas/async-context#readme",
   "dependencies": {
     "async": "1.5.2",
-    "async-utils": "0.0.3",
+    "async-utils": "0.0.5",
     "lodash": "4.17.11",
     "mobile-adk_context": "0.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "1.5.2",
     "async-utils": "0.0.3",
-    "lodash": "4.15.0",
+    "lodash": "4.17.11",
     "mobile-adk_context": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
async-utils v0.0.5 has the same lodash version update.